### PR TITLE
Add EditorConfig; update files with 2-space indent

### DIFF
--- a/www/.editorconfig
+++ b/www/.editorconfig
@@ -1,0 +1,9 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/www/books.template.html
+++ b/www/books.template.html
@@ -1,15 +1,17 @@
 <!doctype html>
 <html>
-  <head>
-    <title>Find Libraries for Books | Results</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="style.css">
-    <script src="json_to_csv.js"></script>
-    <script src="script.js"></script>
-  </head>
-  <body>
-    <h1>Find Libraries for Books</h1>
-    <div>
+
+<head>
+  <title>Find Libraries for Books | Results</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="style.css">
+  <script src="json_to_csv.js"></script>
+  <script src="script.js"></script>
+</head>
+
+<body>
+  <h1>Find Libraries for Books</h1>
+  <div>
     <p>
       In the Overdrive column, you will be told the network that has
       the book available.
@@ -19,29 +21,29 @@
       the Somerville Public Library's account).
     </p>
     <p>
-      The Other column indicates if the book was found in <a
-      href="https://openlibrary.org">Open Library</a> or <a
-      href="https://gutenberg.org">Project Gutenberg</a>.
+      The Other column indicates if the book was found in <a href="https://openlibrary.org">Open Library</a> or <a
+        href="https://gutenberg.org">Project Gutenberg</a>.
     </p>
-    </div>
-    <table border="1">
-      <tr>
-	<th>Title</th>
-	<th>Author</th>
-	<th>Overdrive</th>
-	<th>Hoopla</th>
-	<th>Other</th>
-      </tr>
-{rows}
-    </table>
-    <script>
-const books_json = {books_json};
-    </script>
-    <p>
-      <button onclick="download_books()">Download table as CSV</button>
-    </p>
-    <p>
-      <a href="index.html">New Search</a>
-    </p>
-  </body>
+  </div>
+  <table border="1">
+    <tr>
+      <th>Title</th>
+      <th>Author</th>
+      <th>Overdrive</th>
+      <th>Hoopla</th>
+      <th>Other</th>
+    </tr>
+    {rows}
+  </table>
+  <script>
+    const books_json = { books_json };
+  </script>
+  <p>
+    <button onclick="download_books()">Download table as CSV</button>
+  </p>
+  <p>
+    <a href="index.html">New Search</a>
+  </p>
+</body>
+
 </html>

--- a/www/index.html
+++ b/www/index.html
@@ -15,75 +15,79 @@
   limitations under the License.
 -->
 <html>
-  <head>
-    <title>Find Libraries for Books</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="style.css">
-    <script src="script.js"></script>
-  </head>
-  <body>
-    <h1>Find Libraries for Books</h1>
-    <form method="POST" action="find.cgi">
-      <label>
-	<div>
-	  <p>
-	    This website allows you to check one or more books against
-	    several library networks' ebook lending. It only tells you
-	    about books from your list that you could borrow
-	    immediately, with no wait.
-	  </p>
-	  <p>
-	    The problem it is trying to solve is that if you have a
-	    number of books you want to read, and you don't care which
-	    one you read next, but you want to start reading right
-	    now, then you're out of luck. You have to check each book
-	    against each possible library in turn, until you find one
-	    (or give up and buy one online, which is almost always
-	    easy and available, but costs money instead of making use
-	    of your library).
-	  </p>
-	  <p>
-	    Put the books you're looking for here. One per line, with
-	    the title, a comma, and the author's first and last
-	    names. If there are commas in the title, then wrap the
-	    title in quotation marks. For example:
-	    <ul>
-	      <li>"Frankenstein; Or, The Modern Prometheus", Mary
-		Shelley</li>
-	    </ul>
-	    Using just a part of the title or author's name may work
-	    (such as just their last name), however, it increases the
-	    chance that the system will misidentify the book and so
-	    say the wrong one is present.
-	  </p>
-	  <p>
-	    You can also copy in the full CSV from a <a
-	    href="https://help.goodreads.com/s/article/How-do-I-import-or-export-my-books-1553870934590">Goodreads
-	    export</a>.
-	  </p>
-	</div>
-	<textarea name="books" rows="6" cols="40"></textarea>
-      </label>
+
+<head>
+  <title>Find Libraries for Books</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="style.css">
+  <script src="script.js"></script>
+</head>
+
+<body>
+  <h1>Find Libraries for Books</h1>
+  <form method="POST" action="find.cgi">
+    <label>
       <div>
-	<label>Overdrive subdomains: <input name="overdrive" value="minuteman,bpl"></label>
+        <p>
+          This website allows you to check one or more books against
+          several library networks' ebook lending. It only tells you
+          about books from your list that you could borrow
+          immediately, with no wait.
+        </p>
+        <p>
+          The problem it is trying to solve is that if you have a
+          number of books you want to read, and you don't care which
+          one you read next, but you want to start reading right
+          now, then you're out of luck. You have to check each book
+          against each possible library in turn, until you find one
+          (or give up and buy one online, which is almost always
+          easy and available, but costs money instead of making use
+          of your library).
+        </p>
+        <p>
+          Put the books you're looking for here. One per line, with
+          the title, a comma, and the author's first and last
+          names. If there are commas in the title, then wrap the
+          title in quotation marks. For example:
+        <ul>
+          <li>"Frankenstein; Or, The Modern Prometheus", Mary
+            Shelley</li>
+        </ul>
+        Using just a part of the title or author's name may work
+        (such as just their last name), however, it increases the
+        chance that the system will misidentify the book and so
+        say the wrong one is present.
+        </p>
+        <p>
+          You can also copy in the full CSV from a <a
+            href="https://help.goodreads.com/s/article/How-do-I-import-or-export-my-books-1553870934590">Goodreads
+            export</a>.
+        </p>
       </div>
-      <div>
-	<p>Warning: May be very slow for large numbers of books.</p>
-	<input type="submit" value="Submit">
-      </div>
-    </form>
+      <textarea name="books" rows="6" cols="40"></textarea>
+    </label>
     <div>
-      <h3>About</h3>
-      <p>
-	The source code for this site is at <a href="https://github.com/epw/find-libraries-for-books">https://github.com/epw/find-libraries-for-books</a>.
-      </p>
-      <p>
-	This site just barely does the minimum the author requires of
-	it. There are a lot of improvements that will hopefully be
-	added if the author has time, such as selection of which
-	Overdrive and Hoopla library networks to query, and links to
-	the particular book records when they are found.
-      </p>
+      <label>Overdrive subdomains: <input name="overdrive" value="minuteman,bpl"></label>
     </div>
-  </body>
+    <div>
+      <p>Warning: May be very slow for large numbers of books.</p>
+      <input type="submit" value="Submit">
+    </div>
+  </form>
+  <div>
+    <h3>About</h3>
+    <p>
+      The source code for this site is at <a
+        href="https://github.com/epw/find-libraries-for-books">https://github.com/epw/find-libraries-for-books</a>.
+    </p>
+    <p>
+      This site just barely does the minimum the author requires of
+      it. There are a lot of improvements that will hopefully be
+      added if the author has time, such as selection of which
+      Overdrive and Hoopla library networks to query, and links to
+      the particular book records when they are found.
+    </p>
+  </div>
+</body>
+
 </html>

--- a/www/json_to_csv.js
+++ b/www/json_to_csv.js
@@ -13,44 +13,43 @@
 // limitations under the License.
 
 function convert_to_csv(colnames, array) {
-    const str = [];
+  const str = [];
 
-    for (let el of array) {
-	let line = [];
-	for (let col of colnames) {
-	    if (typeof(el[col]) == "string" && (
-		el[col].indexOf(",") != -1
-		    || el[col].indexOf("\n") != -1)) {
-		line.push('"' + el[col] + '"');
-	    } else {
-		line.push(el[col]);
-	    }
-	}
-	str.push(line.join(","));
+  for (let el of array) {
+    let line = [];
+    for (let col of colnames) {
+      if (typeof (el[col]) == "string" &&
+        (el[col].indexOf(",") != -1 || el[col].indexOf("\n") != -1)) {
+        line.push('"' + el[col] + '"');
+      } else {
+        line.push(el[col]);
+      }
     }
+    str.push(line.join(","));
+  }
 
-    return str.join("\n");
+  return str.join("\n");
 }
 
 function download_csv_file(colnames, array, filename) {
-    const csv = convert_to_csv(colnames, array);
+  const csv = convert_to_csv(colnames, array);
 
-    const blob = new Blob([colnames.join(","), "\n", csv, "\n"],
-			  { type: "text/csv;charset=utf-8;" });
-    if (navigator.msSaveBlob) { // IE 10+
-        navigator.msSaveBlob(blob, filename);
+  const blob = new Blob([colnames.join(","), "\n", csv, "\n"],
+    { type: "text/csv;charset=utf-8;" });
+  if (navigator.msSaveBlob) { // IE 10+
+    navigator.msSaveBlob(blob, filename);
+  } else {
+    const link = document.createElement("a");
+    if (link.download == undefined) {
+      console.error("Link downloads not supported, sorry.");
     } else {
-        const link = document.createElement("a");
-        if (link.download == undefined) {
-	    console.error("Link downloads not supported, sorry.");
-	} else {
-            const url = URL.createObjectURL(blob);
-            link.setAttribute("href", url);
-            link.setAttribute("download", filename);
-            link.style.visibility = 'hidden';
-            document.body.appendChild(link);
-            link.click();
-            document.body.removeChild(link);
-        }
+      const url = URL.createObjectURL(blob);
+      link.setAttribute("href", url);
+      link.setAttribute("download", filename);
+      link.style.visibility = 'hidden';
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
     }
+  }
 }

--- a/www/script.js
+++ b/www/script.js
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 function download_books() {
-    download_csv_file(["title", "author", "overdrive", "hoopla", "other"],
-		      books_json, "table.csv");
+  download_csv_file(["title", "author", "overdrive", "hoopla", "other"],
+    books_json, "table.csv");
 }
 
 function init() {

--- a/www/style.css
+++ b/www/style.css
@@ -15,19 +15,19 @@
  */
 
 h1 {
-    text-align: center;
+  text-align: center;
 }
 
 label > div {
-    margin-bottom: 4px;
+  margin-bottom: 4px;
 }
 
 textarea {
-    margin-bottom: 4px;
+  margin-bottom: 4px;
 }
 
 td {
-    padding-left: 2px;
-    padding-right: 2px;
+  padding-left: 2px;
+  padding-right: 2px;
 }
 


### PR DESCRIPTION
* add a simple cross-editor config file to support 2-space indent on all files
* updated all files to use 2-space indent

Some improvements are possible, e.g., by specifying a 4-space continuation
indent, which EditorConfig doesn't appear to support (yet?)

Fixes https://github.com/epw/find-libraries-for-books/issues/4