### PR TITLE
Add missing Apache 2.0 license header

### DIFF
--- a/www/books.template.html
+++ b/www/books.template.html
@@ -1,4 +1,19 @@
 <!doctype html>
+<!--
+  Copyright 2020 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <html>
   <head>
     <title>Find Libraries for Books | Results</title>


### PR DESCRIPTION
This file was missed in the last batch update in PR https://github.com/epw/find-libraries-for-books/pull/3